### PR TITLE
rename model prop in python client - rk

### DIFF
--- a/client-modules/python/src/taskslock/client/models/task_lock.py
+++ b/client-modules/python/src/taskslock/client/models/task_lock.py
@@ -5,5 +5,5 @@ class TaskLock:
     def __init__(self, api_response: dict, release: Callable):
         self.task_name = api_response['taskName']
         self.context_id = api_response['contextId']
-        self.isLocked = api_response['isLockAcquired']
+        self.is_locked = api_response['isLockAcquired']
         self.release = release


### PR DESCRIPTION
This release features a hotfix for the python TasksLockAPI client.

## Changes

- change TaskLock `is_locked` member name